### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,15 @@ data_files_to_include = ["*.png"]
 if sys.version_info.major == 2:
     try:
         import PySide
-        requires = ['requests']
+        requires = ['requests==2.28.1']
     except:
-        requires = ['requests', 'pyside']
+        requires = ['requests==2.28.1', 'pyside']
 else:
     try:
         import PySide2
-        requires = ['requests']
+        requires = ['requests==2.28.1']
     except:
-        requires = ['requests', 'pyside2']
+        requires = ['requests==2.28.1', 'pyside2']
 
 setuptools.setup(
     name="skyhook",


### PR DESCRIPTION
### Description of Changes

Forcing setup.py to use `requests==2.28.1` because of an error we were getting in Maya. 
